### PR TITLE
Revert adding claypoole

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,6 @@
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [clojure.java-time "0.3.3"]
-                 [com.climate/claypoole "1.1.4"]]
+                 [clojure.java-time "0.3.3"]]
   :plugins [[lein-auto "0.1.3"]]
   :repl-options {:init-ns sisyphus.core})


### PR DESCRIPTION
using claypoole was causing certain tasks to be run more times than scheduled for, and the tasks kept running even after the `(run-tasks!)` function was stopped